### PR TITLE
Bug: Fix Payment Types API Endpoint URLs

### DIFF
--- a/data/payment-types.js
+++ b/data/payment-types.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse, fetchWithoutResponse } from "./fetcher";
 
 export function getPaymentTypes() {
-  return fetchWithResponse('payment-types', {
+  return fetchWithResponse('paymenttypes', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }
@@ -9,7 +9,7 @@ export function getPaymentTypes() {
 }
 
 export function addPaymentType(paymentType) {
-  return fetchWithResponse(`payment-types`, {
+  return fetchWithResponse(`paymenttypes`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
@@ -20,7 +20,7 @@ export function addPaymentType(paymentType) {
 }
 
 export function deletePaymentType(id) {
-  return fetchWithoutResponse(`payment-types/${id}`, {
+  return fetchWithoutResponse(`paymenttypes/${id}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`


### PR DESCRIPTION
## Description
Updated the payment types API endpoint URLs to match the backend specification. Changed all occurrences of `payment-types` to `paymenttypes` (removed hyphen) in the payment types data service functions to ensure proper API communication.

## Related Issues
- #30 
- #29 

## Motivation and Context
The payment types API calls were failing due to a mismatch between the frontend endpoint URLs and the backend API routes. The backend expects `paymenttypes` (without hyphen) but the frontend was calling `payment-types` (with hyphen), causing 404 errors and preventing payment type functionality from working correctly.

## How has this been tested?
- Tested `getPaymentTypes()` function to verify payment types are properly retrieved

## Screenshots (if appropriate):
![Screenshot 2025-07-09 at 6 27 37 PM](https://github.com/user-attachments/assets/c01898b1-8dba-40c2-a3e4-0e010e0998a0)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)