### PR TITLE
display user's liked products on their profile

### DIFF
--- a/data/products.js
+++ b/data/products.js
@@ -121,3 +121,10 @@ export function unLikeProduct(productId) {
   });
 }
 
+export function getLikedProducts() {
+ return fetchWithResponse(`products/liked`, {
+  headers: {
+    Authorization: `Token ${localStorage.getItem("token")}`,
+  },
+ }) 
+}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -6,6 +6,7 @@ import { ProductCard } from '../components/product/card'
 import { StoreCard } from '../components/store/card'
 import { useAppContext } from '../context/state'
 import { getUserProfile } from '../data/auth'
+import { getLikedProducts } from '../data/products'
 
 export default function Profile() {
   const { profile, setProfile } = useAppContext()
@@ -14,6 +15,15 @@ export default function Profile() {
     getUserProfile().then((profileData) => {
       if (profileData) {
         setProfile(profileData)
+
+        // set likes after the profile loads
+        getLikedProducts().then((likedProducts) => {
+          setProfile((prev) => ({
+            ...prev,
+            likes: likedProducts
+          })
+      )
+        })
       }
     })
   }, [])
@@ -21,13 +31,13 @@ export default function Profile() {
   return (
     <>
       <h1 className="title is-3 has-text-weight-semibold has-text-centered mb-5">
-      Hello, {profile?.user?.first_name} {profile?.user?.last_name}!
+      Hello, {profile.user.first_name} {profile.user.last_name}!
       </h1>
 
       <CardLayout title="Favorite Stores" width="is-full">
         <div className="columns is-multiline">
           {
-            profile?.favorites?.map(favorite => (
+            profile.favorites?.map(favorite => (
               <StoreCard store={favorite} key={favorite.id} width="is-one-third" />
             ))
           }
@@ -37,7 +47,7 @@ export default function Profile() {
       <CardLayout title="Products you've recommended" width="is-full">
         <div className="columns is-multiline">
           {
-            profile?.recommended_by?.map(recommendation => (
+            profile.recommended_by?.map(recommendation => (
               <ProductCard product={recommendation.product} key={recommendation.product.id} width="is-one-third" />
             ))
           }
@@ -47,7 +57,7 @@ export default function Profile() {
       <CardLayout title="Products recommended to you" width="is-full">
         <div className="columns is-multiline">
           {
-            profile?.recommendations?.map(recommendation => (
+            profile.recommendations?.map(recommendation => (
               <ProductCard product={recommendation.product} key={recommendation.product.id} width="is-one-third" />
             ))
           }
@@ -58,7 +68,7 @@ export default function Profile() {
       <CardLayout title="Products you've liked" width="is-full">
         <div className="columns is-multiline">
           {
-            profile?.likes?.map(product => (
+            profile.likes?.map(product => (
               <ProductCard product={product} key={product.id} width="is-one-third" />
             ))
           }


### PR DESCRIPTION
## Description
Users can see products they've liked on their profile page.

## Related Issues
Closes #22 

##  Files Changed
[pages/profile.js](https://github.com/Evening-Cohort-29/Bangazon-client-mgitwk/pull/55/files#r2249332822): 
- Get and set user's liked products after the profile loads so they can display correctly on the profile page

[data/products.js](https://github.com/Evening-Cohort-29/Bangazon-client-mgitwk/pull/55/files#r2249337348): 
- Added getLikedProducts() function to call the new /products/liked endpoint.

## How should you test this?
- [ ] First, pull BE changes and run migrations
- [ ] While logged in, like products 
- [ ] Go to profile page, ensure liked products show in the 'Products You've Liked' section

## Screenshots (if appropriate):
<img width="1103" height="961" alt="Screenshot 2025-08-02 at 12 33 15 PM" src="https://github.com/user-attachments/assets/2bff4e94-51bc-4380-8355-6d9de2e0b3ea" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
